### PR TITLE
Asan flag

### DIFF
--- a/compiler-rt/lib/asan/asan_activation_flags.inc
+++ b/compiler-rt/lib/asan/asan_activation_flags.inc
@@ -24,7 +24,6 @@ ASAN_ACTIVATION_FLAG(int, redzone)
 ASAN_ACTIVATION_FLAG(int, max_redzone)
 ASAN_ACTIVATION_FLAG(int, quarantine_size_mb)
 ASAN_ACTIVATION_FLAG(int, thread_local_quarantine_size_kb)
-ASAN_ACTIVATION_FLAG(int, enable_ksm) /* 1: all shadow, 2: incremental */
 ASAN_ACTIVATION_FLAG(bool, alloc_dealloc_mismatch)
 ASAN_ACTIVATION_FLAG(bool, poison_heap)
 
@@ -35,3 +34,4 @@ COMMON_ACTIVATION_FLAG(const char *, coverage_dir)
 COMMON_ACTIVATION_FLAG(int, verbosity)
 COMMON_ACTIVATION_FLAG(bool, help)
 COMMON_ACTIVATION_FLAG(s32, allocator_release_to_os_interval_ms)
+COMMON_ACTIVATION_FLAG(int, enable_ksm) /* 1: all shadow, 2: incremental */

--- a/compiler-rt/lib/asan/asan_activation_flags.inc
+++ b/compiler-rt/lib/asan/asan_activation_flags.inc
@@ -24,6 +24,7 @@ ASAN_ACTIVATION_FLAG(int, redzone)
 ASAN_ACTIVATION_FLAG(int, max_redzone)
 ASAN_ACTIVATION_FLAG(int, quarantine_size_mb)
 ASAN_ACTIVATION_FLAG(int, thread_local_quarantine_size_kb)
+ASAN_ACTIVATION_FLAG(int, enable_ksm) /* 1: all shadow, 2: incremental */
 ASAN_ACTIVATION_FLAG(bool, alloc_dealloc_mismatch)
 ASAN_ACTIVATION_FLAG(bool, poison_heap)
 

--- a/compiler-rt/lib/asan/asan_allocator.cc
+++ b/compiler-rt/lib/asan/asan_allocator.cc
@@ -224,6 +224,7 @@ void AllocatorOptions::SetFrom(const Flags *f, const CommonFlags *cf) {
   may_return_null = cf->allocator_may_return_null;
   alloc_dealloc_mismatch = f->alloc_dealloc_mismatch;
   release_to_os_interval_ms = cf->allocator_release_to_os_interval_ms;
+  enable_ksm = f->enable_ksm;
 }
 
 void AllocatorOptions::CopyTo(Flags *f, CommonFlags *cf) {

--- a/compiler-rt/lib/asan/asan_allocator.cc
+++ b/compiler-rt/lib/asan/asan_allocator.cc
@@ -224,7 +224,7 @@ void AllocatorOptions::SetFrom(const Flags *f, const CommonFlags *cf) {
   may_return_null = cf->allocator_may_return_null;
   alloc_dealloc_mismatch = f->alloc_dealloc_mismatch;
   release_to_os_interval_ms = cf->allocator_release_to_os_interval_ms;
-  enable_ksm = f->enable_ksm;
+  enable_ksm = cf->enable_ksm;
 }
 
 void AllocatorOptions::CopyTo(Flags *f, CommonFlags *cf) {

--- a/compiler-rt/lib/asan/asan_allocator.h
+++ b/compiler-rt/lib/asan/asan_allocator.h
@@ -28,6 +28,12 @@ enum AllocType {
   FROM_NEW_BR = 3   // Memory block came from operator new [ ]
 };
 
+enum EnableKsm {
+  NO_KSM = 0,
+  KSM_ALL_SHADOW = 1,
+  KSM_INCREMENTAL = 2,
+};
+
 struct AsanChunk;
 
 struct AllocatorOptions {
@@ -38,6 +44,7 @@ struct AllocatorOptions {
   u8 may_return_null;
   u8 alloc_dealloc_mismatch;
   s32 release_to_os_interval_ms;
+  u8 enable_ksm;
 
   void SetFrom(const Flags *f, const CommonFlags *cf);
   void CopyTo(Flags *f, CommonFlags *cf);

--- a/compiler-rt/lib/asan/asan_flags.inc
+++ b/compiler-rt/lib/asan/asan_flags.inc
@@ -16,6 +16,9 @@
 // ASAN_FLAG(Type, Name, DefaultValue, Description)
 // See COMMON_FLAG in sanitizer_flags.inc for more details.
 
+ASAN_FLAG(int, enable_ksm, 0,
+          "Enable KSM. (0 - No KSM, 1 - KSM entire shadow memory, "
+          "2 - Incrementally pass shadow memory into KSM)")
 ASAN_FLAG(int, quarantine_size, -1,
             "Deprecated, please use quarantine_size_mb.")
 ASAN_FLAG(int, quarantine_size_mb, -1,

--- a/compiler-rt/lib/asan/asan_flags.inc
+++ b/compiler-rt/lib/asan/asan_flags.inc
@@ -16,9 +16,6 @@
 // ASAN_FLAG(Type, Name, DefaultValue, Description)
 // See COMMON_FLAG in sanitizer_flags.inc for more details.
 
-ASAN_FLAG(int, enable_ksm, 0,
-          "Enable KSM. (0 - No KSM, 1 - KSM entire shadow memory, "
-          "2 - Incrementally pass shadow memory into KSM)")
 ASAN_FLAG(int, quarantine_size, -1,
             "Deprecated, please use quarantine_size_mb.")
 ASAN_FLAG(int, quarantine_size_mb, -1,

--- a/compiler-rt/lib/asan/asan_shadow_setup.cc
+++ b/compiler-rt/lib/asan/asan_shadow_setup.cc
@@ -43,8 +43,10 @@ void ReserveShadowMemoryRange(uptr beg, uptr end, const char *name) {
   if (common_flags()->no_huge_pages_for_shadow) NoHugePagesInRegion(beg, size);
   if (common_flags()->use_madv_dontdump) DontDumpShadowMemory(beg, size);
 
-  if (common_flags()->enable_ksm == 1 /* ksm all shadow */)
+  if (common_flags()->enable_ksm == 1 /* ksm all shadow */) {
+    VReport(1, "madvise(0x%llx, 0x%llx, madv_mergeable)", beg, size);
     madvise((void *)beg, size, MADV_MERGEABLE);
+  }
 }
 
 static void ProtectGap(uptr addr, uptr size) {

--- a/compiler-rt/lib/asan/asan_shadow_setup.cc
+++ b/compiler-rt/lib/asan/asan_shadow_setup.cc
@@ -43,7 +43,8 @@ void ReserveShadowMemoryRange(uptr beg, uptr end, const char *name) {
   if (common_flags()->no_huge_pages_for_shadow) NoHugePagesInRegion(beg, size);
   if (common_flags()->use_madv_dontdump) DontDumpShadowMemory(beg, size);
 
-  madvise((void *)beg, size, MADV_MERGEABLE);
+  if (common_flags()->enable_ksm == 1 /* ksm all shadow */)
+    madvise((void *)beg, size, MADV_MERGEABLE);
 }
 
 static void ProtectGap(uptr addr, uptr size) {

--- a/compiler-rt/lib/asan/asan_shadow_setup.cc
+++ b/compiler-rt/lib/asan/asan_shadow_setup.cc
@@ -44,7 +44,7 @@ void ReserveShadowMemoryRange(uptr beg, uptr end, const char *name) {
   if (common_flags()->use_madv_dontdump) DontDumpShadowMemory(beg, size);
 
   if (common_flags()->enable_ksm == 1 /* ksm all shadow */) {
-    VReport(1, "madvise(0x%llx, 0x%llx, madv_mergeable)", beg, size);
+    VReport(1, "madvise(0x%llx, 0x%llx, madv_mergeable)\n", beg, size);
     madvise((void *)beg, size, MADV_MERGEABLE);
   }
 }

--- a/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
+++ b/compiler-rt/lib/sanitizer_common/sanitizer_flags.inc
@@ -162,6 +162,9 @@ COMMON_FLAG(
 COMMON_FLAG(bool, use_madv_dontdump, true,
           "If set, instructs kernel to not store the (huge) shadow "
           "in core file.")
+COMMON_FLAG(int, enable_ksm, 0,
+            "Enable KSM. (0 - No KSM, 1 - KSM entire shadow memory, "
+            "2 - Incrementally pass shadow memory into KSM)")
 COMMON_FLAG(bool, symbolize_inline_frames, true,
             "Print inlined frames in stacktraces. Defaults to true.")
 COMMON_FLAG(bool, symbolize_vs_style, false,


### PR DESCRIPTION
Usage
```
ASAN_OPTIONS=verbosity=1:enable_ksm=1 ./a.out
```